### PR TITLE
Release - v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# AWS - Base Infrastructure Module
+Terraform module that creates base infrastructure in [GCP](https://cloud.google.com/) for testing [Alkira Network Cloud](https://www.alkira.com/). This module is ideal for deploying a flexible network infrastructure with AWS's low-cost, general-purpose [e2-micro](https://cloud.google.com/compute/docs/machine-types#e2_shared-core_machine_types) instances in each subnet for testing. Instances are provisioned without public IP addresses. This presents a simple and completely private environment, ideal for testing integration to Alkira's _Cloud Services Exchange (CSX)_.
+
+## What It Does
+- Create a [Virtual Private Cloud (VPC)](https://cloud.google.com/vpc)
+- Build one or more [Subnets](https://cloud.google.com/vpc/docs/vpc#manually_created_subnet_ip_ranges) (provided as a list)
+- Build an [Instance](https://cloud.google.com/compute/docs/instances) running [Ubuntu](https://ubuntu.com/) per subnet
+- Push provided _public key_ data to each instance
+- Build and apply [GCP Firewall Rules](https://cloud.google.com/vpc/docs/firewalls) setup with **_any-to-any_** for both **_ingress_** and **_egress_** traffic
+> GCP Firewall is set to _allow-all_ for inbound and outbound traffic because Alkira's policy manages this functionality across all clouds; This would normally be a bad practice and not recommended otherwise
+
+## Usage
+```hcl
+provider "google" {
+  credentials = "${file("credentials.json")}"
+  region      = "us-east4"
+  zone        = "us-east4-a"
+}
+
+module "infra" {
+  source  = "wcollins/gcpinfra/gcp"
+
+  vpc_name         = "vpc-gcp-east"
+  subnet_names     = ["subnet-01", "subnet-02", "subnet-03"]
+  subnet_prefixes  = ["10.3.1.0/24", "10.3.2.0/24", "10.3.3.0/24"]
+  instance_names   = ["vm-gcp-east-01", "vm-gcp-east-02", "vm-gcp-east-03"]
+  project_id       = var.project_id
+  ssh_key          = var.ssh_key
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,56 @@
+resource "google_compute_network" "vpc" {
+  name                    = var.vpc_name
+  project                 = var.project_id
+  description             = var.description
+  routing_mode            = var.routing_mode
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  count                    = length(var.subnet_names)
+  region                   = var.region
+  project                  = var.project_id
+  name                     = var.subnet_names[count.index]
+  ip_cidr_range            = var.subnet_prefixes[count.index]
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true
+}
+
+resource "google_compute_instance" "instance" {
+  count        = length(var.instance_names)
+  name         = var.instance_names[count.index]
+  project      = var.project_id
+  machine_type = var.machine_type
+  tags         = ["all"]
+
+  metadata = {
+    sshKeys = "${var.ssh_user}:${var.ssh_key}"
+  }
+
+  boot_disk {
+    initialize_params {
+      image = var.boot_disk_image
+      type  = var.boot_disk_type
+    }
+  }
+
+  metadata_startup_script = "sudo apt-get update && sudo apt-get -y upgrade && sudo apt-get -y dist-upgrade"
+
+  network_interface {
+    network    = google_compute_network.vpc.self_link
+    subnetwork = google_compute_subnetwork.subnet.*.self_link[count.index]
+  }
+}
+
+resource "google_compute_firewall" "allow-all" {
+  name = "allow-all"
+  project = var.project_id
+  network = google_compute_network.vpc.name
+
+  allow {
+    protocol = "all"
+  }
+
+  target_tags   = ["all"]
+  source_ranges = ["0.0.0.0/0"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_name" {
+  description = "Name of VPC being created"
+  value       = google_compute_network.vpc.name
+}
+
+output "vpc_id" {
+  description = "GCP - VPC ID"
+  value       = google_compute_network.vpc.id
+}
+
+output "network_self_link" {
+  description = "URI of the VPC being created"
+  value       = google_compute_network.vpc.self_link
+}
+
+output "subnet_id" {
+  description = "List of subnet IDs"
+  value       = google_compute_subnetwork.subnet.*.id
+}
+
+output "instance_id" {
+  description = "List of instance IDs"
+  value       = google_compute_instance.instance.*.instance_id
+}
+
+output "private_ip" {
+  description = "List of instance private IP addresses"
+  value       = google_compute_instance.instance.*.network_interface.0.network_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,70 @@
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "vpc_name" {
+  description = "VPC name"
+  type        = string
+}
+
+variable "instance_names" {
+  description = "List of GCP instances"
+  type        = list(string)
+}
+
+variable "subnet_names" {
+  description = "List of subnet names"
+  type        = list(string)
+}
+
+variable "subnet_prefixes" {
+  description = "List of subnet prefixes"
+  type        = list(string)
+}
+
+variable "routing_mode" {
+  description = "GCP network-wide routing mode"
+  type        = string
+  default     = "REGIONAL"
+}
+
+variable "description" {
+  description = "Resource description"
+  type        = string
+  default     = "Managed by Terraform"
+}
+
+variable "project_id" {
+  description = "GCP - Project ID"
+  type        = string
+}
+
+variable "ssh_user" {
+  description = "Default user"
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_key" {
+  description = "Public key data"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "GCP - machine type"
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "boot_disk_image" {
+  description = "GCP - boot disk image"
+  type        = string
+  default     = "ubuntu-os-cloud/ubuntu-1804-lts"
+}
+
+variable "boot_disk_type" {
+  description = "GCP - boot disk type"
+  type        = string
+  default     = "pd-balanced"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.29"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "<4.0,>= 2.12"
+    }
+  }
+}


### PR DESCRIPTION
- Create a [Virtual Private Cloud (VPC)](https://cloud.google.com/vpc)
- Build one or more [Subnets](https://cloud.google.com/vpc/docs/vpc#manually_created_subnet_ip_ranges) (provided as a list)
- Build an [Instance](https://cloud.google.com/compute/docs/instances) running [Ubuntu](https://ubuntu.com/) per subnet
- Push provided _public key_ data to each instance
- Build and apply [GCP Firewall Rules](https://cloud.google.com/vpc/docs/firewalls) setup with **_any-to-any_** for both **_ingress_** and **_egress_** traffic